### PR TITLE
Pass a -march flag for arm64 clang build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -76,9 +76,20 @@ source_set("boringssl_asm") {
       public_configs = [ ":no_asm_config" ]
     }
   } else if (current_cpu == "arm" && (is_linux || is_android)) {
-    sources += crypto_sources_linux_arm
+    if (is_android || !is_clang) {
+      sources += crypto_sources_linux_arm
+    } else {
+      public_configs = [ ":no_asm_config" ]
+    }
   } else if (current_cpu == "arm64" && (is_linux || is_android)) {
-    sources += crypto_sources_linux_aarch64
+    if (is_android || !is_clang) {
+      sources += crypto_sources_linux_aarch64
+    } else {
+      # TODO(zra): The android build doesn't use the integrated assembler when
+      # using clang. Figure out how to specify crypto extensions when using
+      # clang for Linux.
+      public_configs = [ ":no_asm_config" ]
+    }
   } else {
     public_configs = [ ":no_asm_config" ]
   }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -42,13 +42,14 @@ source_set("boringssl_asm") {
   defines = []
   sources = []
   include_dirs = [ "src/include" ]
+  asmflags = []
 
   if ((current_cpu == "arm" || current_cpu == "arm64") && is_android && is_clang) {
     # Disable the integrated assembler and use the one shipped with the NDK.
     import("//build/config/android/config.gni")
     rebased_android_toolchain_root =
         rebase_path(android_toolchain_root, root_build_dir)
-    asmflags = [
+    asmflags += [
       "-fno-integrated-as",
       "-B${rebased_android_toolchain_root}/bin",
     ]
@@ -76,20 +77,10 @@ source_set("boringssl_asm") {
       public_configs = [ ":no_asm_config" ]
     }
   } else if (current_cpu == "arm" && (is_linux || is_android)) {
-    if (is_android || !is_clang) {
-      sources += crypto_sources_linux_arm
-    } else {
-      public_configs = [ ":no_asm_config" ]
-    }
+    sources += crypto_sources_linux_arm
   } else if (current_cpu == "arm64" && (is_linux || is_android)) {
-    if (is_android || !is_clang) {
-      sources += crypto_sources_linux_aarch64
-    } else {
-      # TODO(zra): The android build doesn't use the integrated assembler when
-      # using clang. Figure out how to specify crypto extensions when using
-      # clang for Linux.
-      public_configs = [ ":no_asm_config" ]
-    }
+    sources += crypto_sources_linux_aarch64
+    asmflags += [ "-march=armv8-a+crypto" ]
   } else {
     public_configs = [ ":no_asm_config" ]
   }


### PR DESCRIPTION
Clang build fails on the assembly files.