### PR TITLE
Remove -mthumb when compiling for arm with clang on linux

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -80,6 +80,10 @@ source_set("boringssl_asm") {
     }
   } else if (current_cpu == "arm" && (is_linux || is_android)) {
     sources += crypto_sources_linux_arm
+    if (is_linux) {
+      # The clang integrated assembler can't handle this code with -mthumb.
+      configs -= [ "//build/config/compiler:compiler_arm_thumb" ]
+    }
   } else if (current_cpu == "arm64" && (is_linux || is_android)) {
     sources += crypto_sources_linux_aarch64
     asmflags += [ "-march=armv8-a+crypto" ]


### PR DESCRIPTION
This relies on the introduction of the compiler_arm_thumb config by https://dart-review.googlesource.com/#/c/sdk/+/45740, but must land first so the new boringssl_gen can be DEPS'd in that CL.