### PR TITLE
Use integrated assembler from clang

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -47,14 +47,6 @@ source_set("boringssl_asm") {
   asmflags = []
 
   if ((current_cpu == "arm" || current_cpu == "arm64") && is_android && is_clang) {
-    # Disable the integrated assembler and use the one shipped with the NDK.
-    import("//build/config/android/config.gni")
-    rebased_android_toolchain_root =
-        rebase_path(android_toolchain_root, root_build_dir)
-    asmflags += [
-      "-fno-integrated-as",
-      "-B${rebased_android_toolchain_root}/bin",
-    ]
     if (current_cpu == "arm64") {
       asmflags += ["-Wa,-march=armv8-a+crypto"]
     }


### PR DESCRIPTION
The NDK now ships with an LLVM based toolchain, and using the integrated assembler is just fine. The current setup actually ends up building with whatever `as` is on the path, which isn't necessarily compatible with the clang used to build Flutter/Dart.

Required for https://github.com/flutter/flutter/issues/73757